### PR TITLE
Usenix Sec 2020: Fix incorrect result

### DIFF
--- a/_conferences/usenixsec2020/results.md
+++ b/_conferences/usenixsec2020/results.md
@@ -3,10 +3,10 @@ title: Results
 order: 20
 artifacts:
 
-  - title: "Hybrid Batch Attacks: Finding Black-box Adversarial Examples with Limited Queries"
+  - title: "Big Numbers - Big Troubles: Systematically Analyzing Nonce Leakage in (EC)DSA Implementations"
     badges: "Artifact Evaluated"
     artifact_url: "https://github.com/Fraunhofer-AISEC/DATA"
-    paper_url: "https://www.usenix.org/system/files/sec20-suya.pdf"
+    paper_url: "https://www.usenix.org/system/files/sec20-weiser.pdf"
 
   - title: "PHMon: A Programmable Hardware Monitor and Its Security Use Cases"
     badges: "Artifact Evaluated"


### PR DESCRIPTION
The `Hybrid Batch Attacks` paper was duplicated with the first entry linking to the `Big Numbers - Big Troubles` paper which was missing.