### PR TITLE
WOOT 2019: Add missing artifact

### DIFF
--- a/_conferences/woot2019/results.md
+++ b/_conferences/woot2019/results.md
@@ -10,6 +10,7 @@ artifacts:
 
   - title: "A better zip bomb"
     badges: "Artifact Evaluated"
+    artifact_url: "https://www.bamsoftware.com/hacks/zipbomb/"
     paper_url: "https://www.usenix.org/system/files/woot19-paper_fifield_0.pdf"
 
   - title: "Automatic Wireless Protocol Reverse Engineering"


### PR DESCRIPTION
Added missing artifact for the "A better zip bomb" paper. The url is in the paper under the "Availability" section.