### PR TITLE
USENIX Sec 2023: fix titles

### DIFF
--- a/_conferences/usenixsec2023/results.md
+++ b/_conferences/usenixsec2023/results.md
@@ -565,7 +565,7 @@ artifacts:
     appendix_url: appendix-files/sec23winterae-final26.pdf
     paper_url: https://www.usenix.org/conference/usenixsecurity23/presentation/seidel
 
--   title: 'BugHog'
+-   title: "A Bug's Life: Analyzing the Lifecycle and Mitigation Process of Content Security Policy Bugs"
     badges: 'Badges: Available, Functional, Reproduced'
     artifact_url: https://github.com/DistriNet/BugHog/tree/usenix23-artifact-stable
     appendix_url: appendix-files/sec23winterae-final28.pdf
@@ -847,7 +847,7 @@ artifacts:
     appendix_url: appendix-files/sec23winterae-final84.pdf
     paper_url: https://www.usenix.org/conference/usenixsecurity23/presentation/falk
 
--   title: 'SAFER : Efficient and Error-Tolerant Binary Instrumentation'
+-   title: 'SAFER: Efficient and Error-Tolerant Binary Instrumentation'
     badges: 'Badges: Available, Functional, Reproduced'
     artifact_url: http://seclab.cs.sunysb.edu/seclab/safer
     appendix_url: appendix-files/sec23winterae-final85.pdf


### PR DESCRIPTION
Fixed the `BugHog` title, as that is the name of the framework, not the paper. And also a typo.

---

There are some titles that don't entirely match those in the paper and/or on the USENIX website. However, since they are often displayed on another website (such as Arxiv) and convey the same message, I have kept them unchanged. I'm not sure what the secartifacts policy is, so I could change them if desired.

For example:
```diff
-Pool-Party: Exploiting Browser Resource Pools as Side-Channels for Web Tracking
+Pool-Party: Exploiting Browser Resource Pools for Web Tracking

-WaterBear: Asynchronous BFT with Information-Theoretic Security and Quantum Security
+WaterBear: Practical Asynchronous BFT Matching Security Guarantees of Partially Synchronous BFT
```