### PR TITLE
systex: fix links to 24/25 badges

### DIFF
--- a/_conferences/systex2024/results.md
+++ b/_conferences/systex2024/results.md
@@ -55,13 +55,13 @@ artifacts:
       </td>
       <td width="250px">
         {% if artifact.badges contains "Available" %}
-          <img src="{{ site.baseurl }}/images/systexbadges-available.svg" alt="Artifacts Evaluated: Available">
+          <img src="{{ site.baseurl }}/images/systex24badges-available.svg" alt="Artifacts Evaluated: Available">
         {% endif %}
         {% if artifact.badges contains "Functional" %}
-          <img src="{{ site.baseurl }}/images/systexbadges-functional.svg" alt="Artifacts Evaluated: Functional">
+          <img src="{{ site.baseurl }}/images/systex24badges-functional.svg" alt="Artifacts Evaluated: Functional">
         {% endif %}
         {% if artifact.badges contains "Reusable" %}
-          <img src="{{ site.baseurl }}/images/systexbadges-reusable.svg" alt="Artifacts Evaluated: Reusable">
+          <img src="{{ site.baseurl }}/images/systex24badges-reusable.svg" alt="Artifacts Evaluated: Reusable">
         {% endif %}
       </td>
       <td>

--- a/_conferences/systex2025/results.md
+++ b/_conferences/systex2025/results.md
@@ -46,13 +46,13 @@ artifacts:
       </td>
       <td width="250px">
         {% if artifact.badges contains "Available" %}
-          <img src="{{ site.baseurl }}/images/systexbadges-available.svg" alt="Artifacts Evaluated: Available">
+          <img src="{{ site.baseurl }}/images/systex25badges-available.svg" alt="Artifacts Evaluated: Available">
         {% endif %}
         {% if artifact.badges contains "Functional" %}
-          <img src="{{ site.baseurl }}/images/systexbadges-functional.svg" alt="Artifacts Evaluated: Functional">
+          <img src="{{ site.baseurl }}/images/systex25badges-functional.svg" alt="Artifacts Evaluated: Functional">
         {% endif %}
         {% if artifact.badges contains "Reusable" %}
-          <img src="{{ site.baseurl }}/images/systexbadges-reusable.svg" alt="Artifacts Evaluated: Reusable">
+          <img src="{{ site.baseurl }}/images/systex25badges-reusable.svg" alt="Artifacts Evaluated: Reusable">
         {% endif %}
       </td>
       <td>


### PR DESCRIPTION
Apologies for the overhead. When renaming the systex24/25 badges, I overlooked updating the links on the respective results pages, making the badges not render there.