### PR TITLE
Add ACSAC 2025 artifact evaluation results

### DIFF
--- a/_conferences/acsac2025/call.md
+++ b/_conferences/acsac2025/call.md
@@ -1,0 +1,5 @@
+---
+title: Call for Artifacts
+order: 10
+redirect_to: https://www.acsac.org/2025/submissions/papers/artifacts/
+---

--- a/_conferences/acsac2025/index.md
+++ b/_conferences/acsac2025/index.md
@@ -1,0 +1,6 @@
+---
+title: Evaluation
+order: 0
+---
+
+To help support the reproducibility for research results, ACSAC encourages authors of accepted papers to submit software they develop and datasets they use to perform their research and make them publicly available to the entire community. We believe that this is an important initiative that can help the entire community increase its reputation, and make research in the security field proceeds faster by taking advantage of systems previously built by other researchers. We thank all the authors who participated in this initiative!

--- a/_conferences/acsac2025/results.md
+++ b/_conferences/acsac2025/results.md
@@ -1,0 +1,252 @@
+---
+title: Results
+order: 20
+available_img: ieeexplore_code_available.png
+available_name: Code Available
+reviewed_img: ieeexplore_code_reviewed.png
+reviewed_name: Code Reviewed
+reproducible_img: ieeexplore_code_reproducible.png
+reproducible_name: Code Reproducible
+artifacts:
+- title: 'PP3D: An In-Browser Vision-Based Defense Against Web Behavior Manipulation Attacks'
+  badges: available
+  artifact_url: https://github.com/NISLabUGA/PixelPatrol3D_Code_ACSAC_Artifacts
+- title: No Fish Is Too Big for Flash Boys! Frontrunning on DAG-based Blockchains
+  badges: available
+  artifact_url: https://github.com/EtherCS/DAGFrontrunning-artifact
+- title: 'ELK: Effective Lock-and-Key Technique for Temporal Memory Safety on Embedded Devices in ARMv8-M'
+  badges: available
+  artifact_url: https://github.com/cslab-pnu/ELK
+- title: 'Rescuing the Unpoisoned: Efficient Defense against Knowledge Corruption Attacks on RAG Systems'
+  badges: available
+  artifact_url: https://github.com/SecAI-Lab/RAGDefender
+- title: 'CAUA: A Realistic and Effective Attack on Machine Unlearning under Limited Information'
+  badges: available
+  artifact_url: https://github.com/ballinyz/CAUA-A-Realistic-and-Effective-Attack-on-Machine-Unlearning-under-Limited-Information-artifact.git
+- title: 'R+R: IoT Device Identification Under Realistic Conditions'
+  badges: available
+  artifact_url: https://zenodo.org/records/17078897
+- title: 'Pathfinder: Exploring Path Diversity for Assessing Internet Censorship Inconsistency'
+  badges: available
+  artifact_url: https://github.com/e2ecensor/Pathfinder
+- title: Understanding the Security Impact of CHERI on the Operating System Kernel
+  badges: available
+  artifact_url: https://github.com/mars-research/cheri-impact-artifact
+- title: 'Fooling Machine''s Eyes: Unicode Modifier Letter Evasion Attack'
+  badges: available
+  artifact_url: https://doi.org/10.5281/zenodo.17106797
+- title: Analysis of Encryption Key Zeroization from System-wide Perspective
+  badges: available
+  artifact_url: https://github.com/Tyojan/Periodic-AESKeyFinder
+- title: Non-Bare-Metal User-Space Control-Flow Attestation
+  badges: available
+  artifact_url: https://github.com/sulfurcfa/Sulfur.git
+- title: Gravity of the Situation:Security Analysis on Rocket.Chat E2EE
+  badges: available
+  artifact_url: https://www.dropbox.com/scl/fo/t6isab20x0wjwkfil541w/AHMuI40b4md1BSpj2TMvPxY?rlkey=81hjrp4yjef0j72jzz60qhtoh&st=pg9zojqg&dl=0
+- title: 'TempoNet: Learning Realistic Communication and Timing Patterns for Network Traffic Simulation'
+  badges: available
+  artifact_url: https://github.com/Yuan-Zhang-uestc/DFSSO-based-OIDC
+- title: 'Clouseau: A Hierarchal Multi-Agent Approach For Autonomous Attack Investigation'
+  badges: reviewed
+  artifact_url: https://colab.research.google.com/drive/1JToaXZHblw9yIPd1T3hHQIW57QR_6so9?usp=sharing
+- title: 'False Promises of Passwordless: Defeating Windows Hello through TPM Misuses'
+  badges: reviewed
+  artifact_url: https://github.com/HITLAB-skku/TemplateInjection-POC
+- title: 'APILOT: Improving the Security and Usability of LLM Code Suggestions via Outdated API Mitigation'
+  badges: reviewed
+  artifact_url: https://github.com/Wayne-Bai/APILOT
+- title: 'OTABase: Enhancing Over-the-Air Testing to Detect Memory Crashes in Cellular Basebands'
+  badges: reviewed
+  artifact_url: https://github.com/OTABase/OTABase.git
+- title: 'Siren: A Learning-Based Multi-Turn Attack Framework for Simulating Real-World Human Jailbreak Behaviors'
+  badges: reviewed
+  artifact_url: https://github.com/YiyiyiZhao/siren
+- title: CarDS - Controller Area Network and Automotive Ethernet Realistic Data Set
+  badges: reviewed
+  artifact_url: https://doi.org/10.48328/tudatalib-2179
+- title: 'SnoopDog: Detecting USB Bus Sniffers Using Responsive EMR'
+  badges: reviewed
+  artifact_url: https://github.com/MobiSec-CSE-UTA/SnoopDog
+- title: 'MIZAR: Boosting Secure Three-Party Deep Learning with Co-Designed Sign-Bit Extraction and GPU Acceleration'
+  badges: reviewed
+  artifact_url: https://github.com/CPS4AI/OpenMizar
+- title: 'Sagitta: Facilitating Post-Fuzzing Root Cause Analysis via Data Flow Differencing'
+  badges: reproducible
+  artifact_url: https://github.com/shina-lab/artifact_Sagitta
+- title: 'Supply Chain Reaction: Enhancing the Precision of Vulnerability Triage using Code Reachability Information'
+  badges: reproducible
+  artifact_url: https://zenodo.org/records/17110050
+- title: Environmental Rate Manipulation Attacks on Power Grid Security
+  badges: reproducible
+  artifact_url: https://github.com/Emegua/ERM_Attack
+- title: 'Octopus: Fast Homomorphic Convolution for Secure Neural Network Inference'
+  badges: reproducible
+  artifact_url: https://github.com/yut-Octopus/Octopus.git
+- title: 'Zeus-IoT: Comprehensive Code Signing to Prevent IoT Device Weaponization'
+  badges: reproducible
+  artifact_url: https://github.com/BUseclab/ZEUS_IoT
+- title: Enhancing Noisy Functional Encryption for Privacy-Preserving Machine Learning
+  badges: reproducible
+  artifact_url: https://github.com/JasZal/dyno
+- title: Securing On-device Transformer with Hardware Binding and Reversible Obfuscation
+  badges: reproducible
+  artifact_url: https://github.com/sarendis56/PUF-Transformer-IP-Protection
+- title: Fix it - If you Can! Towards Understanding the Impact of Tool Support and Domain Owners’ Reactions to SSHFP Misconfigurations
+  badges: reproducible
+  artifact_url: https://github.com/gehaxelt/SSHFP-Notification-Study-AE
+- title: Compact and Selective Disclosure for Verifiable Credentials
+  badges: reproducible
+  artifact_url: https://github.com/csdjwt/csd_jwt_artifact_evaluation
+- title: 'TrustLeech: Privileged System Analysis using Nested Virtualization'
+  badges: reproducible
+  artifact_url: https://github.com/ma-schulze/TrustLeech
+- title: 'MoEvil: Poisoning Expert to Compromise the Safety of Mixture-of-Experts LLMs'
+  badges: reproducible
+  artifact_url: https://github.com/jaehanwork/MoEvil
+- title: GET /large.file HTTP/1.1:Connection-Based TCP Amplification Attacks
+  badges: reproducible
+  artifact_url: https://github.com/acsac2025-tcp-amp/acsac2025_tcp_amp
+- title: 'EM-Flow: Advanced Electromagnetic Control Flow Verification for Embedded Systems'
+  badges: reproducible
+  artifact_url: https://gitfront.io/r/c1234/ZVZ2dYSazQWt/emflow-artifact/
+- title: 'InteractionShield: Harnessing Event Relations for Interaction Threat Detection and Resolution in Smart Homes'
+  badges: reproducible
+  artifact_url: https://github.com/InteractionShield/InteractionShield
+- title: 'VerDiff: Vulnerability Presence Verification for Comprehensive Reporting Using Constraint Programming'
+  badges: reproducible
+  artifact_url: https://github.com/mdsakibanwar/verdiff
+- title: Enabling Plausible Deniability in Flash-based Storage through Data Permutation
+  badges: reproducible
+  artifact_url: https://github.com/weidong-zhu/MUTE-ACSAC
+- title: 'In Pursuit of Lean OS Kernels: Improving Configuration-Based Debloating'
+  badges: reproducible
+  artifact_url: https://github.com/akshithg/leanos-artifacts
+- title: 'SMORE: Practical Redzone-Based Stack Memory Error Detection Mechanism for Embedded Systems'
+  badges: reproducible
+  artifact_url: https://github.com/cslab-pnu/SMORE
+- title: 'Revisiting Prime+Prune+Probe: Pitfalls and Remedies'
+  badges: reproducible
+  artifact_url: https://github.com/Chair-for-Security-Engineering/Revisiting-Prime-Prune-Probe
+- title: Leaking Queries On Secure Stream Processing Systems
+  badges: reproducible
+  artifact_url: https://github.com/PhamHung2020/Simple-SGX-based-DSP-Engine
+- title: 'Flashy Backdoor: Real-world Environment Backdoor Attack on SNNs with DVS Cameras'
+  badges: reproducible
+  artifact_url: https://github.com/Yencr0s/Flashy_backdoor
+- title: 'PSan: Towards Hybrid Metadata Scheme for Efficient Pointer Checking'
+  badges: reproducible
+  artifact_url: https://github.com/dlgroupuoft/PSan-ACSAC25
+- title: 'Revealing the True Indicators: Understanding and Improving IoC Extraction From Threat Reports'
+  badges: reproducible
+  artifact_url: https://github.com/EvanFr/LANCE
+- title: Recovering Peripheral Maps and Protocols to Expedite Firmware Reverse Engineering
+  badges: reproducible
+  artifact_url: https://github.com/BayanTurki/ProtoReveal-main
+- title: 'The 2FA Illusion: Uncovering Weak Links of Web Account Access in the Wild'
+  badges: reproducible
+  artifact_url: https://github.com/k3coby/kmap4auth
+- title: 'AndroByte: LLM-Driven Privacy Analysis through Bytecode Summarization and Dynamic Dataflow Call Graph Generation'
+  badges: reproducible
+  artifact_url: https://github.com/Eshita66/AndroByte
+- title: 'DP-Mix: Differentially Private Routing in Mix Networks'
+  badges: reproducible
+  artifact_url: https://github.com/DPMix/DP-Mix
+- title: 'One Detector Fits All: Robust and Adaptive Detection of Malicious Packages from PyPI to Enterprises'
+  badges: reproducible
+  artifact_url: https://github.com/SAP-samples/robust-pypi-detector
+- title: 'DeepProv: Behavioral Characterization and Repair of Neural Networks via Inference Provenance Graph Analysis'
+  badges: reproducible
+  artifact_url: https://github.com/deepprov/DeepProv
+- title: 'FLAME: Flexible and Lightweight Biometric Authentication Scheme in Malicious Environments'
+  badges: reproducible
+  artifact_url: https://github.com/sakurasfy/BioAuth
+- title: 'Uncovering Bigger Truths: Deobfuscating PHP with Phoebe'
+  badges: reproducible
+  artifact_url: https://github.com/ias-tubs/Phoebe
+- title: A Period-Adaptive Traffic Fingerprint-Based Method for Smart Home Device Identification
+  badges: reproducible
+  artifact_url: https://github.com/JasonHYJ/deviceIdentification
+- title: Belt and Braces! Fight against Key Compromising in Single Sign-On Systems
+  badges: reproducible
+- title: 'MimicCall: Bypassing System Call Filters via Kernel Function Redundancy'
+  badges: reproducible
+  artifact_url: https://github.com/koreacsl/MimicCall/tree/artifact
+---
+
+Results automatically obtained from <a href="https://www.acsac.org/2025/program/artifacts/">ACSAC website</a>.
+
+**Evaluation Results**:
+
+* 13 Code Available
+* 8 Code Reviewed
+* 34 Code Reproducible
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        Title
+      </th>
+      <th>
+        Avail.
+      </th>
+      <th>
+        Review.
+      </th>
+      <th>
+        Repro.
+      </th>
+      <th>
+        Available At
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for artifact in page.artifacts %}
+    <tr>
+      <td>
+        {% if artifact.paper_url %}
+        <a href="{{artifact.paper_url}}" target="_blank">
+          {{artifact.title}}
+        </a>
+        {% else %}
+            {{ artifact.title }}
+        {% endif %}
+      </td>
+      <td width="62px">
+        {% if artifact.badges contains "available" %}
+        <img alt="{{ page.available_name }}" src="{{ site.baseurl }}/images/{{ page.available_img }}">
+        {% endif %}
+      </td>
+      <td width="62px">
+        {% if artifact.badges contains "reviewed" %}
+        <img alt="{{ page.reviewed_name }}" src="{{ site.baseurl }}/images/{{ page.reviewed_img }}">
+        {% endif %}
+      </td>
+      <td width="62px">
+        {% if artifact.badges contains "reproducible" %}
+        <img alt="{{ page.reproducible_name }}" src="{{ site.baseurl }}/images/{{ page.reproducible_img }}">
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.artifact_url %}
+            {% assign artifacts = artifact.artifact_url | split: " " %}
+            {% for url in artifacts %}
+        <a href="{{url}}" target="_blank">
+          Artifact
+        </a>
+        <br>
+        {% endfor %}
+        {% endif %}
+        {% if artifact.appendix_url %}
+        <a href="{{artifact.appendix_url}}" target="_blank">
+          Appendix
+        </a>
+        <br>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
Add ACSAC 2025 artifact evaluation results, following the same structure as ACSAC 2024.

Results generated by [`generate_results.py`](https://github.com/ReproDB/reprodb-pipeline/blob/main/src/scrapers/generate_results.py) from the [ReproDB pipeline](https://github.com/ReproDB/reprodb-pipeline), scraping https://www.acsac.org/2025/program/artifacts/

```bash
python -m src.scrapers.generate_results --target secartifacts --conference acsac --years 2025 --output_dir ./_conferences
```

**Evaluation Results:**
- 13 Code Available
- 8 Code Reviewed
- 34 Code Reproducible
- 55 total artifacts

Files added:
- `_conferences/acsac2025/index.md` — Evaluation page
- `_conferences/acsac2025/call.md` — Redirect to ACSAC 2025 call for artifacts
- `_conferences/acsac2025/results.md` — Full results with badges and artifact links