### PR TITLE
Add workflow to trigger ReproDB pipeline on data changes

### DIFF
--- a/.github/workflows/notify-reprodb.yml
+++ b/.github/workflows/notify-reprodb.yml
@@ -1,0 +1,20 @@
+name: Notify ReproDB Pipeline
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '_conferences/**/results.md'
+      - '_conferences/**/organizers.md'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger ReproDB pipeline update
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.REPRODB_DISPATCH_TOKEN }}" \
+            https://api.github.com/repos/ReproDB/reprodb-pipeline/dispatches \
+            -d '{"event_type":"source-data-updated","client_payload":{"source":"secartifacts","ref":"${{ github.sha }}"}}'


### PR DESCRIPTION
When `results.md` or `organizers.md` files under `_conferences/` are updated on `main`, this workflow sends a `repository_dispatch` event to `ReproDB/reprodb-pipeline` so it can automatically regenerate statistics.

**Requires:** A repository secret `REPRODB_DISPATCH_TOKEN` (already configured) with permissions to trigger workflows on `ReproDB/reprodb-pipeline`.